### PR TITLE
feat: improve pipeline step progress visibility

### DIFF
--- a/internal/cli/do.go
+++ b/internal/cli/do.go
@@ -7,6 +7,7 @@ import (
 
 var doPipeline string
 var doForce bool
+var doVerbose bool
 
 var doCmd = &cobra.Command{
 	Use:          "do <spec-file>",
@@ -15,11 +16,12 @@ var doCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		src := &source.SpecSource{Path: args[0]}
-		return runPipeline(cmd.Context(), src, doPipeline, doForce)
+		return runPipeline(cmd.Context(), src, doPipeline, doForce, doVerbose)
 	},
 }
 
 func init() {
 	doCmd.Flags().StringVarP(&doPipeline, "pipeline", "p", "default", "Pipeline to use")
 	doCmd.Flags().BoolVar(&doForce, "force", false, "Skip dirty working tree check")
+	doCmd.Flags().BoolVarP(&doVerbose, "verbose", "v", false, "Stream executor output to terminal")
 }

--- a/internal/cli/pick.go
+++ b/internal/cli/pick.go
@@ -7,6 +7,7 @@ import (
 
 var pickPipeline string
 var pickForce bool
+var pickVerbose bool
 
 var pickCmd = &cobra.Command{
 	Use:          "pick <issue-number>",
@@ -15,11 +16,12 @@ var pickCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		src := &source.GitHubSource{IssueNumber: args[0]}
-		return runPipeline(cmd.Context(), src, pickPipeline, pickForce)
+		return runPipeline(cmd.Context(), src, pickPipeline, pickForce, pickVerbose)
 	},
 }
 
 func init() {
 	pickCmd.Flags().StringVarP(&pickPipeline, "pipeline", "p", "default", "Pipeline to use")
 	pickCmd.Flags().BoolVar(&pickForce, "force", false, "Skip dirty working tree check")
+	pickCmd.Flags().BoolVarP(&pickVerbose, "verbose", "v", false, "Stream executor output to terminal")
 }

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -17,7 +17,7 @@ import (
 )
 
 // runPipeline is the shared entry point for pick and do commands.
-func runPipeline(ctx context.Context, src source.Source, pipelineName string, force bool) error {
+func runPipeline(ctx context.Context, src source.Source, pipelineName string, force bool, verbose bool) error {
 	// Load config
 	cfg, err := config.Load()
 	if err != nil {
@@ -115,7 +115,7 @@ func runPipeline(ctx context.Context, src source.Source, pipelineName string, fo
 	}
 
 	// Run pipeline
-	disp := pipeline.NewDisplay(input.Title)
+	disp := pipeline.NewDisplay(input.Title, verbose)
 	disp.Header()
 
 	engine := &pipeline.Engine{
@@ -124,6 +124,7 @@ func runPipeline(ctx context.Context, src source.Source, pipelineName string, fo
 		Executors: executors,
 		Run:       r,
 		Display:   disp,
+		Verbose:   verbose,
 	}
 
 	return engine.Execute(ctx, pipelineCtx)

--- a/internal/executor/claudecode.go
+++ b/internal/executor/claudecode.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -49,10 +50,20 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req *Request) (*Result
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	if req.Verbose {
+		// Stream stderr to the terminal so the user can see claude's progress.
+		// Stdout is still captured for JSON result parsing.
+		cmd.Stderr = os.Stderr
+	} else {
+		cmd.Stderr = &stderr
+	}
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("claude-code executor: %w\nstderr: %s", err, stderr.String())
+		errDetail := stderr.String()
+		if req.Verbose {
+			errDetail = "(see stderr above)"
+		}
+		return nil, fmt.Errorf("claude-code executor: %w\nstderr: %s", err, errDetail)
 	}
 
 	output := stdout.String()

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -17,6 +17,7 @@ type Request struct {
 	Step       types.Step
 	RunDir     string
 	InputFiles map[string]string // filename → content
+	Verbose    bool              // stream executor output to terminal
 }
 
 // Result holds the output of a step execution.

--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"time"
@@ -39,8 +40,14 @@ func (e *ShellExecutor) Execute(ctx context.Context, req *Request) (*Result, err
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	if req.Verbose {
+		// Stream output to the terminal and also capture for the result.
+		cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	} else {
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+	}
 
 	err := cmd.Run()
 	output := stdout.String()

--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -22,6 +22,7 @@ type Engine struct {
 	Executors map[string]executor.Executor
 	Run       *run.Run
 	Display   *Display
+	Verbose   bool
 }
 
 // stepDisplayModel returns a human-readable label for the step's executor/model,
@@ -162,6 +163,7 @@ func (e *Engine) runExecutorStep(ctx context.Context, step types.Step, pipelineC
 		Step:       step,
 		RunDir:     e.Run.Dir,
 		InputFiles: inputFiles,
+		Verbose:    e.Verbose,
 	}
 
 	result, err := exec.Execute(ctx, req)


### PR DESCRIPTION
## Summary

Closes #7

- **Elapsed time ticker (always on)**: `running...` 라인이 매초 in-place로 업데이트됨 (`running... 23s`). 캐리지 리턴(`\r`)을 이용해 같은 줄을 덮어쓰므로 터미널 스크롤 없이 진행 상황 확인 가능
- **`--verbose` / `-v` 플래그 추가**: `pick`/`do` 명령 모두 지원
  - `claude-code` executor: stderr를 터미널에 실시간 스트리밍 (stdout은 JSON 파싱용으로 계속 캡처)
  - `shell` executor: stdout+stderr를 `io.MultiWriter`로 터미널과 캡처 버퍼에 동시 출력

## Behavior

**Normal mode** (`running...` ticker):
```
⏳ Plan         google/gemini-2.0-flash      running... 12s
✅ Plan         google/gemini-2.0-flash      PLAN.md              $0.0312    4.2s
⏳ Implement    claude-code                  running... 45s
✅ Implement    claude-code                  —                    —          45.2s
```

**Verbose mode** (`vcoding pick 7 --verbose`):
```
⏳ Plan         google/gemini-2.0-flash      running...
✅ Plan         google/gemini-2.0-flash      PLAN.md              $0.0312    4.2s
⏳ Implement    claude-code                  running...
  <claude stderr output streams here in real-time>
✅ Implement    claude-code                  —                    —          45.2s
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests green)