### PR TITLE
feat(display): remove elapsed time ticker during step execution

### DIFF
--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -93,7 +93,6 @@ func RenderTemplate(filename string, data any) (string, error) {
 	return buf.String(), nil
 }
 
-
 func readAll(fsys embed.FS, dir, ext string) (map[string]string, error) {
 	result := map[string]string{}
 	entries, err := fs.ReadDir(fsys, dir)

--- a/internal/cli/stats.go
+++ b/internal/cli/stats.go
@@ -29,8 +29,8 @@ func runStats(cmd *cobra.Command, args []string) error {
 	}
 
 	type runStat struct {
-		id     string
-		meta   run.Meta
+		id   string
+		meta run.Meta
 	}
 
 	var stats []runStat

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -8,9 +8,9 @@ import (
 
 // GitInfo holds current git state.
 type GitInfo struct {
-	Branch string
-	Commit string
-	Diff   string
+	Branch  string
+	Commit  string
+	Diff    string
 	IsDirty bool
 }
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -19,15 +19,15 @@ type Run struct {
 
 // Meta holds metadata about a run, persisted to meta.json.
 type Meta struct {
-	StartedAt  time.Time    `json:"started_at"`
-	InputMode  string       `json:"input_mode"`  // "pick" | "do"
-	InputRef   string       `json:"input_ref"`   // issue number or spec path
-	Status     string       `json:"status"`      // "running" | "completed" | "failed"
-	Steps      []StepResult `json:"steps"`
-	TotalCost  float64      `json:"total_cost"`
-	Error      string       `json:"error,omitempty"`
-	GitBranch  string       `json:"git_branch"`
-	GitCommit  string       `json:"git_commit"`
+	StartedAt time.Time    `json:"started_at"`
+	InputMode string       `json:"input_mode"` // "pick" | "do"
+	InputRef  string       `json:"input_ref"`  // issue number or spec path
+	Status    string       `json:"status"`     // "running" | "completed" | "failed"
+	Steps     []StepResult `json:"steps"`
+	TotalCost float64      `json:"total_cost"`
+	Error     string       `json:"error,omitempty"`
+	GitBranch string       `json:"git_branch"`
+	GitCommit string       `json:"git_commit"`
 }
 
 // StepResult records the outcome of a single step.


### PR DESCRIPTION
## Summary
Remove the real-time elapsed time counter from the step progress display.

## Changes
- Remove 1-second ticker goroutine from `StepStart()`
- Remove `stopTicker()` method and related channels from `Display` struct
- Keep `running...` indicator during execution
- Display total duration (`%.1fs`) only when step completes via `StepDone()`

## Rationale
Reduces visual noise and terminal output spam while still providing timing information upon step completion.

## Before
```
⏳ Plan         z-ai/glm-5                     running... 1s
⏳ Plan         z-ai/glm-5                     running... 2s
⏳ Plan         z-ai/glm-5                     running... 3s
...
```

## After
```
⏳ Plan         z-ai/glm-5                     running...✅ Plan         z-ai/glm-5                     completed                  $0.0012    15.3s
```